### PR TITLE
Refactor/merge rsync image into vanilla image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV ANSIBLE_VERSION=2.5.2
 
 RUN apk --update add --no-cache --virtual .deps gcc libc-dev openssl-dev make \
  && apk add --no-cache libffi-dev \
+    rsync openssh-client \
  && pip install --no-cache-dir "ansible==$ANSIBLE_VERSION" \
  && apk del .deps \
  && rm -rf ~/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV ANSIBLE_VERSION=2.5.2
 RUN apk --update add --no-cache --virtual .deps gcc libc-dev openssl-dev make \
  && apk add --no-cache libffi-dev \
     rsync openssh-client \
+    git \
  && pip install --no-cache-dir "ansible==$ANSIBLE_VERSION" \
  && apk del .deps \
  && rm -rf ~/.cache


### PR DESCRIPTION
* python:2.7.14-alpine3.7
* ansible: 2.5.2
* add rsync, git

---

no longer use rsync image